### PR TITLE
Temp Suppress CVE-2025-48976

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -34,6 +34,7 @@
     <cve>CVE-2023-34055</cve>
     <cve>CVE-2023-52428</cve>
     <cve>CVE-2024-38820</cve>
+    <cve>CVE-2025-48976</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[


### PR DESCRIPTION
### Jira link

### Change description
Got a new [CVE-2025-48976](https://github.com/advisories/GHSA-vv7r-c36w-3prj) on commons-fileupload-1.5.jar where this dependecy is using by idam-java-client.
Suppress temporally until we find an IDAM update

### Security Vulnerability Assessment ###

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

CVE ID(s): CVE-2025-48976
Reason for Suppression/Ignoring: Waiting for update from IDAM
Mitigating Factors/Compensating Controls: Migration tool is only run on occasion and behind firewalls.

### Checklist
- [ ] Does this PR introduce a breaking change
