### PR TITLE
ADOP-2826 Update uk.gov.hmcts.java plugin version to 0.12.70

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
   id 'com.github.kt3k.coveralls' version '2.12.2'
   id 'com.github.ben-manes.versions' version '0.49.0'
   id 'org.sonarqube' version '4.4.1.3373'
-  id 'uk.gov.hmcts.java' version '0.12.68'
+  id 'uk.gov.hmcts.java' version '0.12.70'
 }
 
 group = 'uk.gov.hmcts.reform'

--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ repositories {
 }
 
 ext {
-  log4JVersion = "2.25.3"
+  log4JVersion = "2.25.4"
   lombokVersion = "1.18.44"
   junitVersion = "5.11.4"
   powermockVersion = '2.0.9'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -35,6 +35,8 @@
     <cve>CVE-2023-52428</cve>
     <cve>CVE-2024-38820</cve>
     <cve>CVE-2025-48976</cve>
+    <cve>CVE-2026-33117</cve>
+    <cve>CVE-2026-40974</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -176,6 +176,7 @@
    <cve>CVE-2026-40975</cve>
    <cve>CVE-2026-40973</cve>
    <cve>CVE-2026-40977</cve>
+   <cve>CVE-2026-22731</cve>
 </suppress>
 <suppress>
    <notes>
@@ -184,6 +185,7 @@
    <cve>CVE-2026-22748</cve>
    <cve>CVE-2026-22751</cve>
    <cve>CVE-2026-22746</cve>
+   <cve>CVE-2026-22732</cve>
 </suppress>
   <!--End of DFPL-3225-->
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -156,6 +156,37 @@
     <cve>CVE-2023-20861</cve>
   </suppress>
 
+  <!--DFPL-3225-->
+<suppress>
+   <notes>
+   file names: spring-aop-6.2.6.jar, spring-beans-6.2.6.jar, spring-context-6.2.6.jar, spring-context-support-6.2.6.jar, spring-core-6.2.6.jar, spring-expression-6.2.6.jar, spring-jcl-6.2.6.jar, spring-web-6.2.6.jar, spring-webmvc-6.2.6.jar
+   </notes>
+   <cve>CVE-2026-22740</cve>
+   <cve>CVE-2026-22737</cve>
+   <cve>CVE-2026-22745</cve>
+   <cve>CVE-2026-22741</cve>
+   <cve>CVE-2026-22735</cve>
+</suppress>
+<suppress>
+   <notes>
+   file names: spring-boot-3.4.5.jar, spring-boot-actuator-3.4.5.jar, spring-boot-actuator-autoconfigure-3.4.5.jar, spring-boot-autoconfigure-3.4.5.jar, spring-boot-starter-3.4.5.jar, spring-boot-starter-actuator-3.4.5.jar, spring-boot-starter-aop-3.4.5.jar, spring-boot-starter-json-3.4.5.jar, spring-boot-starter-logging-3.4.5.jar
+   </notes>
+   <cve>CVE-2026-22733</cve>
+   <cve>CVE-2026-40972</cve>
+   <cve>CVE-2026-40975</cve>
+   <cve>CVE-2026-40973</cve>
+   <cve>CVE-2026-40977</cve>
+</suppress>
+<suppress>
+   <notes>
+   file names: spring-security-config-6.5.7.jar, spring-security-core-6.4.5.jar, spring-security-crypto-6.4.5.jar, spring-security-oauth2-client-6.5.7.jar, spring-security-oauth2-core-6.5.7.jar, spring-security-oauth2-jose-6.5.7.jar, spring-security-oauth2-resource-server-6.5.7.jar, spring-security-web-6.4.5.jar
+   </notes>
+   <cve>CVE-2026-22748</cve>
+   <cve>CVE-2026-22751</cve>
+   <cve>CVE-2026-22746</cve>
+</suppress>
+  <!--End of DFPL-3225-->
+
   <!--End of temporary suppression section -->
 
 </suppressions>


### PR DESCRIPTION
### Jira link
[ADOP-2826](https://tools.hmcts.net/jira/browse/ADOP-2826)

### Change description
Bump 'uk.gov.hmcts.java' to fix pipeline dependency checks
Bump log4j-api to fix multiple CVEs
Suppress Spring CVEs to be fixed under [DFPL-3225](https://tools.hmcts.net/jira/browse/DFPL-3225)


### Security Vulnerability Assessment ###

<!-- Comment:
If Yes to the below question, please provide details below:
CVE ID(s): (List all suppressed or relevant CVE IDs)
Reason for Suppression/Ignoring: (e.g., Low risk in our specific context, Mitigating controls in place, False positive - with justification)
Mitigating Factors/Compensating Controls: Describe any measures taken to reduce the risk associated with the vulnerability
-->

**CVE Suppression:** Are there any CVEs present in the codebase (either newly introduced or pre-existing) that are being intentionally suppressed or ignored by this commit?
  * [x] Yes
  * [ ] No

### Checklist

- [ ] Does this PR introduce a breaking change
