### PR TITLE
ADOP-2834: Upgrade to Java 21 and bump dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG APP_INSIGHTS_AGENT_VERSION=3.2.10
-FROM hmctsprod.azurecr.io/base/java:17-distroless
+ARG APP_INSIGHTS_AGENT_VERSION=3.4.12
+FROM hmctsprod.azurecr.io/base/java:21-distroless
 
 USER hmcts
 COPY lib/applicationinsights.json /opt/app/

--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,11 @@ plugins {
   id 'checkstyle'
   id 'jacoco'
   id 'java'
-  id "io.freefair.lombok" version "6.6.3"
   id 'io.spring.dependency-management' version '1.1.7'
-  id 'org.springframework.boot' version '3.4.5'
+  id 'org.springframework.boot' version '3.5.14'
   id 'com.github.kt3k.coveralls' version '2.12.2'
-  id 'com.github.ben-manes.versions' version '0.49.0'
-  id 'org.sonarqube' version '4.4.1.3373'
+  id 'com.github.ben-manes.versions' version '0.54.0'
+  id 'org.sonarqube' version '5.1.0.4882'
   id 'uk.gov.hmcts.java' version '0.12.70'
 }
 
@@ -17,7 +16,7 @@ version = '0.0.1'
 
 java {
   toolchain {
-    languageVersion = JavaLanguageVersion.of(17)
+    languageVersion = JavaLanguageVersion.of(21)
   }
 }
 
@@ -112,29 +111,29 @@ task smoke(type: Test) {
 
 checkstyle {
   maxWarnings = 0
-  toolVersion = '9.3'
+  toolVersion = '13.4.2'
   getConfigDirectory().set(new File(rootDir, 'config/checkstyle'))
 }
 
 jacocoTestReport {
   executionData(test, integration)
   reports {
-    xml.required = true
-    csv.required = false
-    xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
+    xml.getRequired().set(true)
+    csv.getRequired().set(false)
+    xml.outputLocation = file("${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }
 
-project.tasks['sonarqube'].dependsOn jacocoTestReport
+project.tasks['sonar'].dependsOn test, integration, jacocoTestReport
 project.tasks['check'].dependsOn integration
 
-sonarqube {
+sonar {
   properties {
     property "sonar.projectName", "adoption-ccd-case-migration-tool"
     property "sonar.projectKey", "adoption-ccd-case-migration-tool"
     property "sonar.jacoco.reportPath", "${project.buildDir}/jacoco/test.exec"
     property "sonar.exclusions", "**/exception/*.java,**/domain/*.java,**/common/*.java,**/repository/*.java,**/service/*.java,**/ccd/*.java,**/migration/auth/*.java,**/migration/*.java,**/ccd/HttpMessageConverterConfiguration.java,**/util/ResourceReader.java,**/model/*.java"
-    property "sonar.coverage.jacoco.xmlReportPaths", "${jacocoTestReport.reports.xml.destination.path}"
+    property "sonar.coverage.jacoco.xmlReportPaths", "${project.buildDir}/reports/jacoco/test/jacocoTestReport.xml"
   }
 }
 
@@ -169,10 +168,10 @@ repositories {
 ext {
   log4JVersion = "2.25.4"
   lombokVersion = "1.18.44"
-  junitVersion = "5.11.4"
+  junitVersion = "5.12.2"
   powermockVersion = '2.0.9'
   springSecurity   =  '6.5.9'
-  springCloudVersion = '2024.0.3'
+  springCloudVersion = '2025.1.1'
 }
 
 ext['jackson.version'] = '2.14.1'
@@ -202,10 +201,10 @@ dependencies {
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '3.0.0'
-  implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '4.9.2'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
+  implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.7.0'
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 
@@ -228,7 +227,7 @@ dependencyManagement {
   }
 
   dependencies {
-    dependency 'com.google.guava:guava:30.1.1-jre'
+    dependency 'com.google.guava:guava:33.6.0-jre'
 
     dependencySet(group: 'commons-beanutils', version: '1.11.0') {
       entry 'commons-beanutils'
@@ -263,7 +262,7 @@ configurations.all {
 test {
   timeout = Duration.ofMinutes(30)
   environment("AZURE_APPLICATIONINSIGHTS_INSTRUMENTATIONKEY", "some-key")
-  systemProperty 'java.locale.providers', 'COMPAT'
+  systemProperty 'java.locale.providers', 'CLDR'
 
   useJUnitPlatform()
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -17,180 +17,23 @@
 
   <!--Please add all the temporary suppression under the below section-->
   <suppress>
-    <notes>Temporary Suppression</notes>
-    <cve>CVE-2023-34034</cve>
-    <cve>CVE-2016-1000027</cve>
-    <cve>CVE-2020-5412</cve>
-    <cve>CVE-2022-22976</cve>
-    <cve>CVE-2022-31690</cve>
-    <cve>CVE-2022-31692</cve>
-    <cve>CVE-2021-37533</cve>
-    <cve>CVE-2023-20860</cve>
-    <cve>CVE-2023-20863</cve>
-    <cve>CVE-2023-20873</cve>
-    <cve>CVE-2023-20862</cve>
-    <cve>CVE-2023-20883</cve>
-    <cve>CVE-2023-34034</cve>
-    <cve>CVE-2023-34055</cve>
-    <cve>CVE-2023-52428</cve>
-    <cve>CVE-2024-38820</cve>
-    <cve>CVE-2025-48976</cve>
+    <cve>CVE-2022-1471</cve>
     <cve>CVE-2026-33117</cve>
     <cve>CVE-2026-40974</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: commons-lang3-3.17.0.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.apache\.commons/commons-lang3@.*$</packageUrl>
+    <cve>CVE-2026-40975</cve>
+    <cve>CVE-2026-40972</cve>
+    <cve>CVE-2026-40973</cve>
+    <cve>CVE-2026-22748</cve>
+    <cve>CVE-2026-40976</cve>
+    <cve>CVE-2026-22746</cve>
+    <cve>CVE-2026-40977</cve>
+    <cve>CVE-2026-22733</cve>
+    <cve>CVE-2026-22732</cve>
+    <cve>CVE-2026-22731</cve>
+    <cve>CVE-2025-48976</cve>
+    <cve>CVE-2026-40970</cve>
+    <cve>CVE-2026-22751</cve>
+    <cve>CVE-2026-40971</cve>
     <cve>CVE-2025-48924</cve>
   </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: LatencyUtils-2.0.3.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.latencyutils/LatencyUtils@.*$</packageUrl>
-    <cve>CVE-2021-4277</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: snakeyaml-1.30.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2021-4235</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: snakeyaml-1.30.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2022-3064</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: commons-fileupload-1.4.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/commons\-fileupload/commons\-fileupload@.*$</packageUrl>
-    <cve>CVE-2023-24998</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: jackson-core-2.14.1.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/com\.fasterxml\.jackson\.core/jackson\-core@.*$</packageUrl>
-    <cve>CVE-2022-45688</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: json-smart-2.4.8.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/net\.minidev/json\-smart@.*$</packageUrl>
-    <cve>CVE-2022-45688</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: snakeyaml-1.33.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2022-1471</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: accessors-smart-2.4.8.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/net\.minidev/accessors\-smart@.*$</packageUrl>
-    <cve>CVE-2022-45688</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-aop-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-aop@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-beans-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-beans@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-context-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-context-support-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-context\-support@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-core-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-core@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-expression-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-expression@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-jcl-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-jcl@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-   file name: spring-webmvc-5.3.22.jar
-   ]]></notes>
-    <packageUrl regex="true">^pkg:maven/org\.springframework/spring\-webmvc@.*$</packageUrl>
-    <cve>CVE-2023-20861</cve>
-  </suppress>
-
-  <!--DFPL-3225-->
-<suppress>
-   <notes>
-   file names: spring-aop-6.2.6.jar, spring-beans-6.2.6.jar, spring-context-6.2.6.jar, spring-context-support-6.2.6.jar, spring-core-6.2.6.jar, spring-expression-6.2.6.jar, spring-jcl-6.2.6.jar, spring-web-6.2.6.jar, spring-webmvc-6.2.6.jar
-   </notes>
-   <cve>CVE-2026-22740</cve>
-   <cve>CVE-2026-22737</cve>
-   <cve>CVE-2026-22745</cve>
-   <cve>CVE-2026-22741</cve>
-   <cve>CVE-2026-22735</cve>
-</suppress>
-<suppress>
-   <notes>
-   file names: spring-boot-3.4.5.jar, spring-boot-actuator-3.4.5.jar, spring-boot-actuator-autoconfigure-3.4.5.jar, spring-boot-autoconfigure-3.4.5.jar, spring-boot-starter-3.4.5.jar, spring-boot-starter-actuator-3.4.5.jar, spring-boot-starter-aop-3.4.5.jar, spring-boot-starter-json-3.4.5.jar, spring-boot-starter-logging-3.4.5.jar
-   </notes>
-   <cve>CVE-2026-22733</cve>
-   <cve>CVE-2026-40972</cve>
-   <cve>CVE-2026-40975</cve>
-   <cve>CVE-2026-40973</cve>
-   <cve>CVE-2026-40977</cve>
-   <cve>CVE-2026-22731</cve>
-</suppress>
-<suppress>
-   <notes>
-   file names: spring-security-config-6.5.7.jar, spring-security-core-6.4.5.jar, spring-security-crypto-6.4.5.jar, spring-security-oauth2-client-6.5.7.jar, spring-security-oauth2-core-6.5.7.jar, spring-security-oauth2-jose-6.5.7.jar, spring-security-oauth2-resource-server-6.5.7.jar, spring-security-web-6.4.5.jar
-   </notes>
-   <cve>CVE-2026-22748</cve>
-   <cve>CVE-2026-22751</cve>
-   <cve>CVE-2026-22746</cve>
-   <cve>CVE-2026-22732</cve>
-</suppress>
-  <!--End of DFPL-3225-->
-
-  <!--End of temporary suppression section -->
-
 </suppressions>

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ADOP-2834

Larger changes:

Upgrade Java and Appinsights to match base FPL ccd config
Bump junit version to match jUnit 5 usage on tests to stop conflicting deps
Change deprecated systemProperty COMPAT -> CLDR for Java 21
Removed io.freefair.lombok never used
Upgrade Gradle version for compatability

Bumped Dependencies:
- service-auth-provider-java-client
- Bump org.springframework.boot
- com.github.ben-manes.versions
- checkstyle
- springCloudVersion
- core-case-data-store-client
- springdoc-openapi-ui
- com.google.guava:guava

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change
