### PR TITLE
ADOP-2834-2: Adjust version bumps for dependencies to prevent bean conflicts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -171,7 +171,7 @@ ext {
   junitVersion = "5.12.2"
   powermockVersion = '2.0.9'
   springSecurity   =  '6.5.9'
-  springCloudVersion = '2025.1.1'
+  springCloudVersion = '2025.0.2'
 }
 
 ext['jackson.version'] = '2.14.1'
@@ -201,10 +201,10 @@ dependencies {
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '6.1.9'
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: '6.1.9'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.3'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.2.0'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.8.0'
+  implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.0.2'
 
   testImplementation group: 'org.springframework.boot', name: 'spring-boot-starter-test'
 

--- a/src/main/java/uk/gov/hmcts/reform/migration/CaseMigrationRunner.java
+++ b/src/main/java/uk/gov/hmcts/reform/migration/CaseMigrationRunner.java
@@ -21,9 +21,7 @@ import java.util.List;
     "uk.gov.hmcts.reform.fpl"
 }, scanBasePackageClasses = {IdamClient.class})
 @EnableFeignClients(basePackages = {
-    "uk.gov.hmcts.reform.idam.client",
-    "uk.gov.hmcts.reform.ccd.client",
-    "uk.gov.hmcts.reform.authorisation",
+    "uk.gov.hmcts.reform.idam.client"
 })
 public class CaseMigrationRunner implements CommandLineRunner {
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/ADOP-2834

Drop version to not import springboot 4.0 features and add property to prevent web server being spun up by spring

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change
