### PR TITLE
DFPL-3193: Update deps and remove outdated suppressions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ repositories {
 }
 
 ext {
-  log4JVersion = "2.26.0"
+  log4JVersion = "2.26.1"
   lombokVersion = "1.18.46"
   junitVersion = "5.12.2"
   powermockVersion = '2.0.9'

--- a/build.gradle
+++ b/build.gradle
@@ -170,13 +170,13 @@ ext {
   lombokVersion = "1.18.46"
   junitVersion = "5.12.2"
   powermockVersion = '2.0.9'
-  springSecurity   =  '6.5.10'
-  springCloudVersion = '2025.1.2'
+  springSecurity   =  '6.5.11'
+  springCloudVersion = '2025.0.3'
 }
 
-ext['jackson.version'] = '2.14.1'
-ext['snakeyaml.version'] = '1.33'
-ext['spring-security.version'] = '6.4.5'
+ext['jackson.version'] = '2.18.9'
+ext['snakeyaml.version'] = '2.0'
+ext['spring-security.version'] = '6.5.11'
 
 dependencies {
   implementation("org.springframework.cloud:spring-cloud-starter-bootstrap")
@@ -191,16 +191,17 @@ dependencies {
   implementation group: 'org.springframework.security', name: 'spring-security-config', version: springSecurity
 
   implementation group: 'commons-io', name: 'commons-io', version: '2.22.0'
+  implementation 'org.apache.commons:commons-lang3:3.20.0'
 
-  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.5.34'
-  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.5.34'
+  implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.6.3'
+  implementation group: 'ch.qos.logback', name: 'logback-core', version: '1.6.3'
   implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: log4JVersion
   implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: log4JVersion
   implementation group: 'net.logstash.logback', name: 'logstash-logback-encoder', version: '8.1'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: '8.0.0'
   implementation group: 'com.github.hmcts', name: 'idam-java-client', version: '3.0.5'
-  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.2'
+  implementation group: 'com.github.hmcts', name: 'service-auth-provider-java-client', version: '5.3.5'
   implementation group: 'com.github.hmcts', name: 'core-case-data-store-client', version: '5.3.0'
 
   implementation group: 'jakarta.validation', name: 'jakarta.validation-api', version: '3.1.1'
@@ -232,7 +233,7 @@ dependencyManagement {
       entry 'commons-beanutils'
     }
 
-    dependencySet(group: 'org.apache.groovy', version: '4.0.32') {
+    dependencySet(group: 'org.apache.groovy', version: '4.0.33') {
       entry 'groovy'
       entry 'groovy-xml'
       entry 'groovy-json'

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -15,25 +15,7 @@
   </suppress>
   <!--End of false positives section -->
 
-  <!--Please add all the temporary suppression under the below section-->
+  <!--Please add all the temporary suppression under the below section
   <suppress>
-    <cve>CVE-2022-1471</cve>
-    <cve>CVE-2026-33117</cve>
-    <cve>CVE-2026-40974</cve>
-    <cve>CVE-2026-40975</cve>
-    <cve>CVE-2026-40972</cve>
-    <cve>CVE-2026-40973</cve>
-    <cve>CVE-2026-22748</cve>
-    <cve>CVE-2026-40976</cve>
-    <cve>CVE-2026-22746</cve>
-    <cve>CVE-2026-40977</cve>
-    <cve>CVE-2026-22733</cve>
-    <cve>CVE-2026-22732</cve>
-    <cve>CVE-2026-22731</cve>
-    <cve>CVE-2025-48976</cve>
-    <cve>CVE-2026-40970</cve>
-    <cve>CVE-2026-22751</cve>
-    <cve>CVE-2026-40971</cve>
-    <cve>CVE-2025-48924</cve>
-  </suppress>
+  </suppress>-->
 </suppressions>


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DFPL-3193

Update Deps to match most up to date version for current spring-boot version

Note: Idam client + auth client cannot be bumped until we've upgraded to spring boot 4. Currently cloud and security are at their most up to date version for Spring 3

- [X] commit messages are meaningful and follow good commit message guidelines
- [ ] Does this PR introduce a breaking change
